### PR TITLE
Update permissions and change uvicorn port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,9 +61,7 @@ LABEL version="0.0.1"
 # "Binds" section maps the host PC directories to the application directories
 LABEL permissions='\
 {\
-  "ExposedPorts": {\
-    "8000/tcp": {}\
-  },\
+  "NetworkMode": "host",\
   "HostConfig": {\
     "Privileged": true,\
     "Binds":[\
@@ -73,17 +71,8 @@ LABEL permissions='\
     ],\
     "CpuQuota": 100000,\
     "CpuPeriod": 100000,\
-    "ExtraHosts": [\
-      "host.docker.internal:host-gateway"\
-    ],\
     "NetworkMode": "host",\
-    "PortBindings": {\
-      "8000/tcp": [\
-        {\
-          "HostPort": ""\
-        }\
-      ]\
-    }\
+    "PortBindings": null\
   }\
 }'
 
@@ -107,4 +96,4 @@ LABEL links='{\
     }'
 LABEL requirements="core >= 1.1"
 
-ENTRYPOINT ["uvicorn", "app.main:app", "--host", "0.0.0.0"]
+ENTRYPOINT ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "9132"]

--- a/README.md
+++ b/README.md
@@ -18,22 +18,26 @@ Information for users
  
 ## Developer Information
 
-To manually install the extension in BlueOS
+To build the docker image and upload to Docker Hub:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm/v7,linux/arm64/v8 . -t {your_dockerhub_id}/blueos-ppp:0.0.1 --output type=registry
+```
+
+To manually install the extension in BlueOS:
 
 - Open the BlueOS Extensions tab, select "Installed"
 - Push the "+" button on the bottom right
 - Under "Create Extension" complete these fields
-  - Extension Identifier: {your_dockerhub_user}.blueos-ppp
+  - Extension Identifier: {your_dockerhub_id}.blueos-ppp
   - Extension Name: PPP
-  - Docker image: {your_dockerhub_user}/blueos-ppp
+  - Docker image: {your_dockerhub_id}/blueos-ppp
   - Dockertag: 0.0.1
   - Settings: add the settings below in the editor
 
 ```json
 {
-  "ExposedPorts": {
-    "8000/tcp": {}
-  },
+  "NetworkMode": "host",
   "HostConfig": {
     "Privileged": true,
     "Binds": [
@@ -43,17 +47,8 @@ To manually install the extension in BlueOS
     ],
     "CpuQuota": 100000,
     "CpuPeriod": 100000,
-    "ExtraHosts": [
-      "host.docker.internal:host-gateway"
-    ],
     "NetworkMode": "host",
-    "PortBindings": {
-      "8000/tcp": [
-        {
-          "HostPort": ""
-        }
-      ]
-    }
+    "PortBindings": null
   }
 }
 ```

--- a/app/main.py
+++ b/app/main.py
@@ -347,4 +347,4 @@ logger.addHandler(fh)
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=9132)

--- a/app/static/register_service
+++ b/app/static/register_service
@@ -1,7 +1,7 @@
 {
     "name":"PPP",
     "description":"BlueOS Extension to run PPP",
-    "icon":"mdi-arrow",
+    "icon":"mdi-lan-connect",
     "company":"ArduPilot",
     "version":"0.0.1",
     "new_page": false,


### PR DESCRIPTION
Fix port settings and ensure other services can see the autopilot.

## Details

- NetworkMode "host" is required for other services to access AutoPilot via PPP.
- The uvicorn port change is required to prevent a conflict other extensions.
- Change the icon.